### PR TITLE
Upgrade crds from v1beta to v1

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -245,7 +245,9 @@ func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]ClusterCondition, len(*in))
-		copy(*out, *in)
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/crd/clusterregistry.k8s.cisco.com_clusters.yaml
+++ b/crd/clusterregistry.k8s.cisco.com_clusters.yaml
@@ -1,181 +1,179 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: clusters.clusterregistry.k8s.cisco.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.clusterID
-    name: ID
-    priority: 1
-    type: string
-  - JSONPath: .status.state
-    name: Status
-    type: string
-  - JSONPath: .status.type
-    name: Type
-    type: string
-  - JSONPath: .status.conditions[?(@.type=="ClustersSynced")].status
-    name: Synced
-    type: string
-  - JSONPath: .status.version
-    name: Version
-    priority: 1
-    type: string
-  - JSONPath: .status.provider
-    name: Provider
-    priority: 1
-    type: string
-  - JSONPath: .status.distribution
-    name: Distribution
-    priority: 1
-    type: string
-  - JSONPath: .status.locality.region
-    name: Region
-    priority: 1
-    type: string
-  - JSONPath: .status.message
-    name: Status Message
-    priority: 1
-    type: string
-  - JSONPath: .status.conditions[?(@.type=="ClustersSynced")].message
-    name: Sync Message
-    priority: 1
-    type: string
   group: clusterregistry.k8s.cisco.com
   names:
     kind: Cluster
     listKind: ClusterList
     plural: clusters
     singular: cluster
-  preserveUnknownFields: false
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Cluster is the Schema for the clusters API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ClusterSpec defines the desired state of Cluster
-          properties:
-            authInfo:
-              description: AuthInfo holds information that describes how a client
-                can get credentials to access the cluster.
-              properties:
-                secretRef:
-                  description: Equivalent of types.NamespacedName with JSON tags
-                  properties:
-                    name:
-                      type: string
-                    namespace:
-                      type: string
-                  type: object
-              type: object
-            clusterID:
-              description: UID of the kube-system namespace
-              type: string
-          required:
-          - clusterID
-          type: object
-        status:
-          description: ClusterStatus defines the observed state of Cluster
-          properties:
-            conditions:
-              description: Conditions contains the different condition statuses for
-                this cluster.
-              items:
-                description: ClusterCondition contains condition information for a
-                  cluster.
-                properties:
-                  lastHeartbeatTime:
-                    description: LastHeartbeatTime is the last time this condition
-                      was updated.
-                    format: date-time
-                    type: string
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition
-                      changed from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Message is a human-readable message indicating details
-                      about the last status change.
-                    type: string
-                  reason:
-                    description: Reason is a (brief) reason for the condition's last
-                      status change.
-                    type: string
-                  status:
-                    description: Status is the status of the condition. One of True,
-                      False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the cluster condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            distribution:
-              type: string
-            kubeProxyVersions:
-              items:
-                type: string
-              type: array
-            kubeletVersions:
-              items:
-                type: string
-              type: array
-            leader:
-              type: boolean
-            locality:
-              properties:
-                region:
-                  type: string
-                regions:
-                  items:
-                    type: string
-                  type: array
-                zones:
-                  items:
-                    type: string
-                  type: array
-              type: object
-            message:
-              type: string
-            provider:
-              type: string
-            state:
-              type: string
-            type:
-              type: string
-            version:
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.clusterID
+      name: ID
+      priority: 1
+      type: string
+    - jsonPath: .status.state
+      name: Status
+      type: string
+    - jsonPath: .status.type
+      name: Type
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ClustersSynced")].status
+      name: Synced
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      priority: 1
+      type: string
+    - jsonPath: .status.provider
+      name: Provider
+      priority: 1
+      type: string
+    - jsonPath: .status.distribution
+      name: Distribution
+      priority: 1
+      type: string
+    - jsonPath: .status.locality.region
+      name: Region
+      priority: 1
+      type: string
+    - jsonPath: .status.message
+      name: Status Message
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ClustersSynced")].message
+      name: Sync Message
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec defines the desired state of Cluster
+            properties:
+              authInfo:
+                description: AuthInfo holds information that describes how a client
+                  can get credentials to access the cluster.
+                properties:
+                  secretRef:
+                    description: Equivalent of types.NamespacedName with JSON tags
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
+              clusterID:
+                description: UID of the kube-system namespace
+                type: string
+            required:
+            - clusterID
+            type: object
+          status:
+            description: ClusterStatus defines the observed state of Cluster
+            properties:
+              conditions:
+                description: Conditions contains the different condition statuses
+                  for this cluster.
+                items:
+                  description: ClusterCondition contains condition information for
+                    a cluster.
+                  properties:
+                    lastHeartbeatTime:
+                      description: LastHeartbeatTime is the last time this condition
+                        was updated.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition
+                        changed from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message is a human-readable message indicating
+                        details about the last status change.
+                      type: string
+                    reason:
+                      description: Reason is a (brief) reason for the condition's
+                        last status change.
+                      type: string
+                    status:
+                      description: Status is the status of the condition. One of True,
+                        False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the cluster condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              distribution:
+                type: string
+              kubeProxyVersions:
+                items:
+                  type: string
+                type: array
+              kubeletVersions:
+                items:
+                  type: string
+                type: array
+              leader:
+                type: boolean
+              locality:
+                properties:
+                  region:
+                    type: string
+                  regions:
+                    items:
+                      type: string
+                    type: array
+                  zones:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              message:
+                type: string
+              provider:
+                type: string
+              state:
+                type: string
+              type:
+                type: string
+              version:
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/crd/clusterregistry.k8s.cisco.com_resourcesyncrules.yaml
+++ b/crd/clusterregistry.k8s.cisco.com_resourcesyncrules.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: resourcesyncrules.clusterregistry.k8s.cisco.com
 spec:
@@ -14,226 +14,226 @@ spec:
     listKind: ResourceSyncRuleList
     plural: resourcesyncrules
     singular: resourcesyncrule
-  preserveUnknownFields: false
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ResourceSyncRule is the Schema for the resource sync rule API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            groupVersionKind:
-              properties:
-                group:
-                  type: string
-                kind:
-                  type: string
-                version:
-                  type: string
-              type: object
-            rules:
-              items:
-                properties:
-                  match:
-                    items:
-                      properties:
-                        annotations:
-                          items:
-                            properties:
-                              matchAnnotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              matchExpressions:
-                                items:
-                                  description: A annotation selector requirement is
-                                    a selector that contains values, a key, and an
-                                    operator that relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                            type: object
-                          type: array
-                        content:
-                          items:
-                            properties:
-                              key:
-                                type: string
-                              value:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - key
-                            - value
-                            type: object
-                          type: array
-                        labels:
-                          items:
-                            description: A label selector is a label query over a
-                              set of resources. The result of matchLabels and matchExpressions
-                              are ANDed. An empty label selector matches all objects.
-                              A null label selector matches no objects.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          type: array
-                        namespaces:
-                          items:
-                            type: string
-                          type: array
-                        objectKey:
-                          properties:
-                            name:
-                              type: string
-                            namespace:
-                              type: string
-                          type: object
-                      required:
-                      - namespaces
-                      type: object
-                    type: array
-                  mutations:
-                    properties:
-                      annotations:
-                        properties:
-                          add:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          remove:
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      groupVersionKind:
-                        properties:
-                          group:
-                            type: string
-                          kind:
-                            type: string
-                          version:
-                            type: string
-                        type: object
-                      labels:
-                        properties:
-                          add:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          remove:
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      overrides:
-                        items:
-                          properties:
-                            parseValue:
-                              type: boolean
-                            path:
-                              type: string
-                            type:
-                              type: string
-                            value:
-                              type: string
-                          type: object
-                        type: array
-                      syncStatus:
-                        type: boolean
-                    type: object
-                type: object
-              type: array
-          required:
-          - groupVersionKind
-          - rules
-          type: object
-        status:
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ResourceSyncRule is the Schema for the resource sync rule API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              groupVersionKind:
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              rules:
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          annotations:
+                            items:
+                              properties:
+                                matchAnnotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                matchExpressions:
+                                  items:
+                                    description: A annotation selector requirement
+                                      is a selector that contains values, a key, and
+                                      an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                          content:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - key
+                              - value
+                              type: object
+                            type: array
+                          labels:
+                            items:
+                              description: A label selector is a label query over
+                                a set of resources. The result of matchLabels and
+                                matchExpressions are ANDed. An empty label selector
+                                matches all objects. A null label selector matches
+                                no objects.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            type: array
+                          namespaces:
+                            items:
+                              type: string
+                            type: array
+                          objectKey:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        required:
+                        - namespaces
+                        type: object
+                      type: array
+                    mutations:
+                      properties:
+                        annotations:
+                          properties:
+                            add:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        groupVersionKind:
+                          properties:
+                            group:
+                              type: string
+                            kind:
+                              type: string
+                            version:
+                              type: string
+                          type: object
+                        labels:
+                          properties:
+                            add:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        overrides:
+                          items:
+                            properties:
+                              parseValue:
+                                type: boolean
+                              path:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        syncStatus:
+                          type: boolean
+                      type: object
+                  type: object
+                type: array
+            required:
+            - groupVersionKind
+            - rules
+            type: object
+          status:
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/scripts/download-deps.sh
+++ b/scripts/download-deps.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-controller_gen_version=0.3.0
+controller_gen_version=0.6.2
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 binpath=${script_dir}/../bin


### PR DESCRIPTION
### What's in this PR?
- modify the scripts to download controller-gen v0.6.2
- run `make manifests` to regenerate v1 version crds


### Why?
Part of SMM-342 task. Crds are used at these places at Backyards repo:
- https://github.com/banzaicloud/backyards/blob/master/services/operator/deploy/charts/smm-operator/crds/clusters-crd.yaml
- https://github.com/banzaicloud/backyards/blob/master/services/operator/deploy/charts/smm-operator/crds/resourcesyncrules-crd.yaml