### PR TITLE
namespace field match should be optional

### DIFF
--- a/api/v1alpha1/resourcesyncrule_types.go
+++ b/api/v1alpha1/resourcesyncrule_types.go
@@ -61,7 +61,7 @@ type SyncRuleMatch struct {
 	Annotations []AnnotationSelector   `json:"annotations,omitempty"`
 	Content     []ContentSelector      `json:"content,omitempty"`
 	Labels      []metav1.LabelSelector `json:"labels,omitempty"`
-	Namespaces  []string               `json:"namespaces"`
+	Namespaces  []string               `json:"namespaces,omitempty"`
 	ObjectKey   types.ObjectKey        `json:"objectKey,omitempty"`
 }
 

--- a/crd/clusterregistry.k8s.cisco.com_resourcesyncrules.yaml
+++ b/crd/clusterregistry.k8s.cisco.com_resourcesyncrules.yaml
@@ -168,8 +168,6 @@ spec:
                               namespace:
                                 type: string
                             type: object
-                        required:
-                        - namespaces
                         type: object
                       type: array
                     mutations:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Makes namespace field optional at matching. 